### PR TITLE
Add light mode redesign and psychedelic mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,24 @@
         <li><a href="#skills">Skills</a></li>
         <li><a href="#contact">Contact</a></li>
       </ul>
+      <button id="theme-toggle" aria-label="Toggle light/dark mode" title="Toggle theme">
+        <!-- Sun icon (shown in dark mode) -->
+        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="5"/>
+          <line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+          <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+        </svg>
+        <!-- Moon icon (shown in light mode) -->
+        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+        </svg>
+        <!-- Sparkle icon (shown in psychedelic mode) -->
+        <svg class="icon-psychedelic" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 2 L13.2 10.8 L22 12 L13.2 13.2 L12 22 L10.8 13.2 L2 12 L10.8 10.8 Z"/>
+        </svg>
+      </button>
     </div>
   </nav>
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,3 +1,18 @@
+// Theme toggle — cycles dark → light → psychedelic → dark
+const root = document.documentElement;
+const themeBtn = document.getElementById('theme-toggle');
+const MODES = ['dark', 'light', 'psychedelic'];
+const saved = localStorage.getItem('theme');
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+root.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+
+themeBtn.addEventListener('click', () => {
+  const current = root.getAttribute('data-theme');
+  const next = MODES[(MODES.indexOf(current) + 1) % MODES.length];
+  root.setAttribute('data-theme', next);
+  localStorage.setItem('theme', next);
+});
+
 // Navbar scroll effect
 const navbar = document.getElementById('navbar');
 window.addEventListener('scroll', () => {

--- a/docs/style.css
+++ b/docs/style.css
@@ -14,6 +14,30 @@
   --nav-h: 64px;
 }
 
+[data-theme="light"] {
+  --bg: #ffffff;
+  --glass: rgba(255, 255, 255, 0.85);
+  --glass-border: rgba(0, 0, 0, 0.1);
+  --text: #0d1117;
+  --text-muted: #44556b;
+  --cyan: #0099bb;
+  --violet: #5c33cc;
+  --emerald: #00aa77;
+  --pink: #cc3399;
+}
+
+[data-theme="psychedelic"] {
+  --bg: #0a0010;
+  --glass: rgba(30, 0, 60, 0.5);
+  --glass-border: rgba(255, 0, 255, 0.15);
+  --text: #ffffff;
+  --text-muted: #dd88ff;
+  --cyan: #00ffff;
+  --violet: #ff00ff;
+  --emerald: #00ff88;
+  --pink: #ff0066;
+}
+
 html { scroll-behavior: smooth; }
 
 body {
@@ -23,6 +47,7 @@ body {
   font-size: 16px;
   line-height: 1.7;
   overflow-x: hidden;
+  transition: background 0.3s, color 0.3s;
 }
 
 a { color: var(--cyan); text-decoration: none; }
@@ -90,6 +115,11 @@ a:hover { text-decoration: underline; }
   inset: 0;
   background-image: radial-gradient(circle, rgba(255,255,255,0.04) 1px, transparent 1px);
   background-size: 36px 36px;
+  transition: background-image 0.3s;
+}
+
+[data-theme="light"] .aurora::after {
+  background-image: radial-gradient(circle, rgba(0,0,0,0.06) 1px, transparent 1px);
 }
 
 /* Grain overlay */
@@ -154,6 +184,159 @@ section, nav, footer { position: relative; z-index: 2; }
 .nav-links a.active {
   color: var(--text);
   text-decoration: none;
+}
+
+/* ── LIGHT MODE OVERRIDES ── */
+[data-theme="light"] #navbar {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+[data-theme="light"] #hero h1 {
+  background: linear-gradient(135deg, #0d1117 20%, var(--cyan) 60%, var(--violet) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+[data-theme="light"] .project-tags span {
+  background: rgba(0,0,0,0.05);
+  border-color: rgba(0,0,0,0.1);
+  color: var(--text-muted);
+}
+
+[data-theme="light"] .contact-link {
+  background: rgba(0,0,0,0.04);
+}
+
+[data-theme="light"] .timeline-date {
+  background: rgba(0,153,187,0.08);
+  border-color: rgba(0,153,187,0.2);
+}
+
+[data-theme="light"] .aurora-orb { opacity: 0.28; }
+[data-theme="light"] .aurora-orb:nth-child(2) { opacity: 0.22; }
+[data-theme="light"] .aurora-orb:nth-child(3) { opacity: 0.18; }
+
+[data-theme="light"] .aurora::after {
+  background-image: radial-gradient(circle, rgba(0,0,0,0.07) 1px, transparent 1px);
+}
+
+/* ── PSYCHEDELIC MODE ── */
+[data-theme="psychedelic"] #navbar {
+  background: rgba(10, 0, 16, 0.88);
+  border-bottom-color: rgba(255, 0, 255, 0.25);
+}
+
+[data-theme="psychedelic"] .aurora-orb {
+  opacity: 0.5;
+  animation: drift 6s ease-in-out infinite alternate, hueShift 4s linear infinite;
+}
+[data-theme="psychedelic"] .aurora-orb:nth-child(2) {
+  opacity: 0.45;
+  animation: drift 8s ease-in-out infinite alternate, hueShift 6s linear infinite reverse;
+}
+[data-theme="psychedelic"] .aurora-orb:nth-child(3) {
+  opacity: 0.4;
+  animation: drift 5s ease-in-out infinite alternate, hueShift 3s linear infinite;
+}
+
+@keyframes hueShift {
+  from { filter: blur(80px) hue-rotate(0deg); }
+  to   { filter: blur(80px) hue-rotate(360deg); }
+}
+
+[data-theme="psychedelic"] #hero h1 {
+  background: linear-gradient(90deg, #ff0066, #ff00ff, #00ffff, #00ff88, #ffff00, #ff0066);
+  background-size: 300% 100%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: rainbowSlide 3s linear infinite;
+}
+
+@keyframes rainbowSlide {
+  0%   { background-position: 0% 50%; }
+  100% { background-position: 300% 50%; }
+}
+
+[data-theme="psychedelic"] .glass,
+[data-theme="psychedelic"] .project-card,
+[data-theme="psychedelic"] .stat,
+[data-theme="psychedelic"] .contact-card {
+  animation: cardPulse 3s ease-in-out infinite alternate;
+}
+
+@keyframes cardPulse {
+  0%   { border-color: rgba(255,0,255,0.35); box-shadow: 0 0 24px rgba(255,0,255,0.12); }
+  33%  { border-color: rgba(0,255,255,0.35); box-shadow: 0 0 32px rgba(0,255,255,0.15); }
+  66%  { border-color: rgba(0,255,136,0.35); box-shadow: 0 0 28px rgba(0,255,136,0.12); }
+  100% { border-color: rgba(255,0,102,0.35); box-shadow: 0 0 36px rgba(255,0,102,0.15); }
+}
+
+[data-theme="psychedelic"] .skill-tags span {
+  animation: tagGlow 2s ease-in-out infinite alternate;
+}
+
+@keyframes tagGlow {
+  from { filter: brightness(1); }
+  to   { filter: brightness(1.7) saturate(1.6); }
+}
+
+[data-theme="psychedelic"] .hero-badge {
+  animation: badgePulse 1s ease-in-out infinite alternate;
+}
+
+@keyframes badgePulse {
+  from { box-shadow: 0 0 8px var(--emerald); }
+  to   { box-shadow: 0 0 28px var(--emerald), 0 0 56px rgba(0,255,136,0.3); }
+}
+
+[data-theme="psychedelic"] .aurora::after {
+  background-image: radial-gradient(circle, rgba(255,0,255,0.14) 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+/* ── THEME TOGGLE BUTTON ── */
+#theme-toggle {
+  background: var(--glass);
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+#theme-toggle:hover {
+  color: var(--cyan);
+  border-color: rgba(6,214,240,0.3);
+}
+
+/* Icon visibility per mode */
+[data-theme="dark"] .icon-moon,
+[data-theme="dark"] .icon-psychedelic,
+[data-theme="light"] .icon-sun,
+[data-theme="light"] .icon-psychedelic,
+[data-theme="psychedelic"] .icon-sun,
+[data-theme="psychedelic"] .icon-moon { display: none; }
+
+[data-theme="dark"] .icon-sun,
+[data-theme="light"] .icon-moon,
+[data-theme="psychedelic"] .icon-psychedelic { display: block; }
+
+/* Psychedelic toggle button animation */
+[data-theme="psychedelic"] #theme-toggle {
+  animation: iconGlow 1.5s ease-in-out infinite alternate;
+}
+
+@keyframes iconGlow {
+  from { color: #ff00ff; border-color: rgba(255,0,255,0.5); box-shadow: 0 0 12px rgba(255,0,255,0.3); }
+  to   { color: #00ffff; border-color: rgba(0,255,255,0.5); box-shadow: 0 0 12px rgba(0,255,255,0.3); }
 }
 
 /* ── HERO ── */


### PR DESCRIPTION
- Light mode: expanded CSS variable overrides for accent colors (darker cyan/violet/emerald/pink for readability on white), fixed hardcoded dark rgba values on project tags, contact links, timeline badges, and aurora dot grid; bumped orb opacity so the aurora is visible on white bg
- Psychedelic mode: new [data-theme="psychedelic"] with deep purple-black bg, fully saturated neon accents, hue-rotating aurora orbs, rainbow sliding gradient on hero name, pulsing card borders/glows, glowing skill tags, intensified badge pulse, tighter neon dot grid
- Toggle cycles dark → light → psychedelic → dark (sparkle icon for psychedelic mode, animated cyan↔magenta glow on the button itself)
- All 3 modes persist via localStorage