### PR TITLE
Add full experience history and set psychedelic as default theme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -142,7 +142,7 @@
           <div class="timeline-content">
             <div class="timeline-header">
               <h4>Staff Technical Engagement Engineer</h4>
-              <span class="timeline-date">Present</span>
+              <span class="timeline-date">Mar 2026 – Present</span>
             </div>
             <p class="timeline-company"><a href="https://crusoe.ai" target="_blank" rel="noopener">Crusoe</a></p>
             <ul>
@@ -157,13 +157,55 @@
           <div class="timeline-content">
             <div class="timeline-header">
               <h4>Technical Marketing Engineer</h4>
-              <span class="timeline-date">Previous</span>
+              <span class="timeline-date">Feb 2023 – Mar 2026</span>
             </div>
             <p class="timeline-company"><a href="https://loft.sh" target="_blank" rel="noopener">loft-sh</a> · vCluster</p>
             <ul>
               <li>Drove technical marketing for vCluster, the leading open-source virtual Kubernetes cluster solution</li>
               <li>Created demos, tutorials, blog posts, and video content for cloud-native audiences</li>
               <li>Contributed to CNCF ecosystem projects including Knative, DevPod, and DevSpace</li>
+            </ul>
+          </div>
+        </div>
+        <div class="timeline-item reveal">
+          <div class="timeline-dot"></div>
+          <div class="timeline-content">
+            <div class="timeline-header">
+              <h4>Technical Marketing Engineer</h4>
+              <span class="timeline-date">Apr 2021 – Feb 2023</span>
+            </div>
+            <p class="timeline-company">Platform9, Remote</p>
+            <ul>
+              <li>Created content around the Platform9 Kubernetes product including blogs, documentation, webinars, and demos</li>
+              <li>Helped new users get up to speed on the product through hands-on technical content</li>
+            </ul>
+          </div>
+        </div>
+        <div class="timeline-item reveal">
+          <div class="timeline-dot"></div>
+          <div class="timeline-content">
+            <div class="timeline-header">
+              <h4>Developer Advocate</h4>
+              <span class="timeline-date">Jul 2017 – Feb 2021</span>
+            </div>
+            <p class="timeline-company">IBM, Remote</p>
+            <ul>
+              <li>Managed the IBM Developer Cloud Account and contributed to open source projects including Knative and Tekton</li>
+              <li>Created demos and content to help developers get up to speed on IBM Kubernetes Service and OpenShift</li>
+            </ul>
+          </div>
+        </div>
+        <div class="timeline-item reveal">
+          <div class="timeline-dot"></div>
+          <div class="timeline-content">
+            <div class="timeline-header">
+              <h4>Senior OpenStack Operations Engineer</h4>
+              <span class="timeline-date">Apr 2014 – Jul 2017</span>
+            </div>
+            <p class="timeline-company">Mirantis, Remote</p>
+            <ul>
+              <li>Helped customers troubleshoot and resolve issues in their OpenStack environments</li>
+              <li>Served as an escalation point for the tier 1 team and helped train the original US-based OpenStack Operations team</li>
             </ul>
           </div>
         </div>
@@ -382,6 +424,6 @@
     </div>
   </footer>
 
-  <script src="script.js?v=4"></script>
+  <script src="script.js?v=5"></script>
 </body>
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -13,8 +13,7 @@ function setTheme(mode) {
 }
 
 const saved = localStorage.getItem('theme');
-const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-setTheme(saved || (prefersDark ? 'dark' : 'light'));
+setTheme(saved || 'psychedelic');
 
 opts.forEach(btn => btn.addEventListener('click', () => setTheme(btn.dataset.mode)));
 


### PR DESCRIPTION
- Add Platform9 TME (Apr 2021–Feb 2023), IBM Developer Advocate (Jul 2017–Feb 2021), and Mirantis Senior OpenStack Operations Engineer (Apr 2014–Jul 2017) to experience timeline
- Fix dates: loft-sh Feb 2023–Mar 2026, Crusoe Mar 2026–Present
- Set psychedelic mode as the default theme on first load